### PR TITLE
feat: make the rule fixable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Via CLI
 textlint --rule no-hankaku-kana README.md
 ```
 
+## Fixable
+
+[![Textlint fixable](https://img.shields.io/badge/textlint-fixable-green.svg?style=social)](https://textlint.github.io/) 
+
+`textlint --fix` での自動修正に対応しています。
+
+*   NFCで表現できる濁点・半濁点はNFCに修正
+    *   例：ﾊﾟﾝﾀﾞはパンダに修正
+*   NFCで表現できない濁点・半濁点はNFDに修正
+    *   例：ｱ&#xff9e;は[ア&#x3099;](https://ja.wikipedia.org/wiki/%E3%81%82%E3%82%99)に修正
+    *   例：ﾂ&#xff9f;は[ツ&#x309a;](https://ja.wikipedia.org/wiki/%E3%83%84%E3%82%9C)に修正
+
 ## Changelog
 
 See [Releases page](https://github.com/textlint-ja/textlint-rule-no-hankaku-kana/releases).

--- a/test/textlint-rule-no-hankaku-kana-test.ts
+++ b/test/textlint-rule-no-hankaku-kana-test.ts
@@ -16,6 +16,7 @@ tester.run("no-hankaku-kana", rule, {
     invalid: [
         {
             text: "ｶﾀｶﾅ",
+            output: "カタカナ",
             errors: [
                 {
                     message: `Disallow to use 半角カタカナ: "ｶﾀｶﾅ"`,
@@ -26,6 +27,7 @@ tester.run("no-hankaku-kana", rule, {
         // multiple hit items in a line
         {
             text: `ｶﾀｶﾅはゼンカクとﾊﾝｶｸがある`,
+            output: `カタカナはゼンカクとハンカクがある`,
             errors: [
                 {
                     message: `Disallow to use 半角カタカナ: "ｶﾀｶﾅ"`,
@@ -42,6 +44,7 @@ tester.run("no-hankaku-kana", rule, {
         // multiple match in multiple lines
         {
             text: "ｶﾀｶﾅ\nﾊﾝｶｸ",
+            output: "カタカナ\nハンカク",
             errors: [
                 {
                     message: `Disallow to use 半角カタカナ: "ｶﾀｶﾅ"`,
@@ -71,6 +74,26 @@ tester.run("no-hankaku-kana", rule, {
                     }
                 }
             ]
-        }
+        },
+        {
+            text: `NFCで表現できる濁点・半濁点はNFCに修正する：ﾊﾟﾝﾀﾞ`,
+            output: `NFCで表現できる濁点・半濁点はNFCに修正する：パンダ`,
+            errors: [
+                {
+                    message: `Disallow to use 半角カタカナ: "ﾊﾟﾝﾀﾞ"`,
+                    range: [25, 30]
+                },
+            ]
+        },
+        {
+            text: `NFCで表現できない濁点・半濁点はNFDに修正する：ｱ\u{ff9e}ﾂ\u{ff9f}`,
+            output: `NFCで表現できない濁点・半濁点はNFDに修正する：ア\u{3099}ツ\u{309a}`,
+            errors: [
+                {
+                    message: `Disallow to use 半角カタカナ: "ｱ\u{ff9e}ﾂ\u{ff9f}"`,
+                    range: [26, 30]
+                },
+            ]
+        },
     ]
 });


### PR DESCRIPTION
Unicode assigns corresponding full-width characters to the characters covered by this rule, so they can be converted to full-width using NFKC or NFKD normalization.

https://unicode.org/charts/PDF/UFF00.pdf

![](https://github.com/textlint-ja/textlint-rule-no-hankaku-kana/assets/270905/a2a320fd-cf6e-4743-9702-faabfdaad1d6)

The figure shows that U+FF61 is narrow version of U+3002 i.e. corresponding full-width character for U+FF61 is U+3002.
 
In this pull request, I have implemented a fixer using NFKC.

Due to the mechanism of NFKC, voiced and semi-voiced marks that can be expressed in NFC are represented in NFC, while those that cannot be expressed in NFC become NFD.